### PR TITLE
Fix comments typo

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -72,7 +72,7 @@ Somewhere, in your node project:
 ```javascript
 var JOII = require("joii");
 
-var MyClass = JOII.Class({ /* ... /* });
+var MyClass = JOII.Class({ /* ... */ });
 ```
 
 #### Node & Global Scope


### PR DESCRIPTION
Found a little typo under Node section.
```JOII.Class({ /* ... /* });```
should be 
```JOII.Class({ /* ... */ });```

My first pull request ever on github.. little one.
Kindly review and merge.
thanks : )